### PR TITLE
Fix store link to rev2.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@
 | [T-TWR Rev2.1][2] | ESP32-S3R8 | 16MB  | 8MB(OPI) |
 
 [1]: https://www.lilygo.cc/products/t-twr-plus
-[2]: https://www.lilygo.cc/products/t-twr-plus
+[2]: https://www.lilygo.cc/products/t-twr-rev2-1
 
 ## 2️⃣Examples
 


### PR DESCRIPTION
rev2.1 now appears to be available in the store, update the link accordingly